### PR TITLE
Fixes #14 migrate ansible playbook from cc-pilot repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,16 @@
 /log/*
 !/log/.keep
 /tmp
+spec/examples.txt
 
 .project
 .DS_Store
 dump.rdb
+
+# Ansible artifacts
+playbooks/hosts
+playbooks/roles
+playbooks/*.retry
+playbooks/*.log
+playbooks/.vaultpassword
+playbooks/.vagrant

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,0 +1,15 @@
+DAMS 5 "Horton" Ansible Playbook
+=============================
+
+Installs dependencies for Hyrax as listed on [Hyrax
+repository](https://github.com/projecthydra-labs/hyrax#prerequisites).
+
+Dependencies:
+1. [Vagrant](http://vagrantup.com/)
+2. [VirtualBox](https://www.virtualbox.org/)
+
+Steps:
+
+1. `cd playbooks; ./setup.sh`
+2. `./setup.sh` - This will install all required roles
+2. `vagrant up`

--- a/playbooks/Vagrantfile
+++ b/playbooks/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "centos/7"
+  #config.vm.box = "ubuntu/precise64"
+
+  config.vm.provision :ansible do |ansible|
+     ansible.playbook = "playbook.yml"
+     ansible.groups = {
+        "horton" => ["default"]
+     }
+     ansible.extra_vars = {
+        do_update: true
+     }
+  end
+end

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+inventory = hosts
+log_path = /tmp/ansible-horton.log
+retry_files_save_path = .
+# vault_password_file = .vaultpassword
+roles_path=roles

--- a/playbooks/config/roles.yml
+++ b/playbooks/config/roles.yml
@@ -1,0 +1,10 @@
+---
+
+- ucsdlib.fedora-commons
+- ucsdlib.ffmpeg
+- ucsdlib.fits
+- ucsdlib.imagemagick-jpeg2000
+- ucsdlib.libreoffice
+- ucsdlib.postgresql
+- ucsdlib.redis
+- ucsdlib.solr

--- a/playbooks/hosts-sample
+++ b/playbooks/hosts-sample
@@ -1,0 +1,2 @@
+[horton]
+default

--- a/playbooks/playbook.yml
+++ b/playbooks/playbook.yml
@@ -1,0 +1,28 @@
+---
+
+- hosts: horton
+  become: true
+
+  vars:
+    - do_update: false
+
+  roles:
+    - ucsdlib.fedora-commons
+    # TODO: write start script for Fedora Commons
+    - { role: 'ucsdlib.ffmpeg', ffmpeg_version: 'release' }
+    - ucsdlib.fits
+    - ucsdlib.imagemagick-jpeg2000
+    # TODO: Determine if RHEL 7 ImageMagick is sufficient
+    - ucsdlib.libreoffice
+    - ucsdlib.postgresql
+    - ucsdlib.redis
+    - ucsdlib.solr
+
+  pre_tasks:
+    - name: Update Packages
+      package:
+        name: '*'
+        state: latest
+      when: do_update
+
+# TODO: setup postgresql databases and users

--- a/playbooks/setup.sh
+++ b/playbooks/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd $(dirname "$0")
+
+echo 'Installing required Ansible roles... '
+
+ansible-galaxy install --role-file=config/roles.yml --roles-path=roles


### PR DESCRIPTION
This PR:
* Migrates the playbook and config that @jhriv setup in the CC-pilot repo
* Renames CC things to Hyrax in anticipation of #15 
* Renames primary group to `horton` to match repo name convention used in cc-pilot repo