### PR TITLE
Fixes configuring Sidekiq as a queue option. #17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,8 @@ gem 'hyrax', '0.0.1.alpha', github: 'projecthydra-labs/hyrax'
 gem 'flipflop', github: 'jcoyne/flipflop', branch: 'hydra'
 gem 'hydra-role-management'
 
+gem 'sidekiq'
+
 gem 'active-fedora', '11.0.0.rc7'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.4)
+    connection_pool (2.2.0)
     daemons (1.2.4)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
@@ -474,6 +475,8 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
     rack (2.0.1)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.1)
@@ -590,6 +593,11 @@ GEM
       rdoc (~> 4.0)
     select2-rails (3.5.10)
       thor (~> 0.14)
+    sidekiq (4.2.3)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.2, >= 3.2.1)
     signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -717,6 +725,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  sidekiq
   simplecov (~> 0.11.2)
   solr_wrapper (>= 0.3)
   spring

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ rails s
 ```
 Go to http://localhost:3000/ and register to start
 
+### Start Sidekiq in another window
+```
+bundle exec sidekiq
+```
+
 ### Adding an admin role to the last user
 ```bash
 rake add_admin_role

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module MyApp
       g.test_framework :rspec, :spec => true
     end
 
+    config.active_job.queue_adapter = :sidekiq
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   
+  require 'sidekiq/web'
+  mount Sidekiq::Web => '/sidekiq'
+
   mount BrowseEverything::Engine => '/browse'
   mount Blacklight::Engine => '/'
   

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,8 @@
+---
+:concurrency: 5
+:queues:
+  - high
+  - ingest
+  - default
+
+


### PR DESCRIPTION
https://github.com/ucsdlib/horton/issues/17sidekiq 
Start Sidekiq in a separate tab/window with:
`bundle install`
`bundle exec sidekiq`