### PR TITLE
Fixes #52 - Updated A-Z links to uppercase.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -48,8 +48,8 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field solr_name("creator", :facetable), label: "Creator", limit: 20, index_range: 'a'..'z'
-    config.add_facet_field solr_name('topic', :facetable), :label => 'Topic', :limit => 20, index_range: 'a'..'z'
+    config.add_facet_field solr_name("creator", :facetable), label: "Creator", limit: 20, index_range: 'A'..'Z'
+    config.add_facet_field solr_name('topic', :facetable), :label => 'Topic', :limit => 20, index_range: 'A'..'Z'
     config.add_facet_field solr_name("language", :facetable), label: "Language", limit: 20
     config.add_facet_field solr_name("publisher", :facetable), label: "Publisher", limit: 20
     config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 20

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -128,16 +128,16 @@ feature 'Visitor wants to browse and search' do
       sign_in user
     end
 
-    scenario 'topic facet page has a-z links' do
+    scenario 'topic facet page has A-Z links' do
       visit facet_catalog_path("topic_sim", :'facet.sort' => 'index')
-      expect(page).to have_link('a', href: '/catalog/facet/topic_sim?facet.prefix=a&facet.sort=index' )
-      expect(page).to have_link('z', href: '/catalog/facet/topic_sim?facet.prefix=z&facet.sort=index' )
+      expect(page).to have_link('A', href: '/catalog/facet/topic_sim?facet.prefix=A&facet.sort=index' )
+      expect(page).to have_link('Z', href: '/catalog/facet/topic_sim?facet.prefix=Z&facet.sort=index' )
     end
 
-    scenario 'creator facet page has a-z links' do
+    scenario 'creator facet page has A-Z links' do
       visit facet_catalog_path("creator_sim", :'facet.sort' => 'index')
-      expect(page).to have_link('a', href: '/catalog/facet/creator_sim?facet.prefix=a&facet.sort=index' )
-      expect(page).to have_link('z', href: '/catalog/facet/creator_sim?facet.prefix=z&facet.sort=index' )
+      expect(page).to have_link('A', href: '/catalog/facet/creator_sim?facet.prefix=A&facet.sort=index' )
+      expect(page).to have_link('Z', href: '/catalog/facet/creator_sim?facet.prefix=Z&facet.sort=index' )
     end
   end
 end


### PR DESCRIPTION
Fixes #52 ; refs #52

Work to port A-Z link functionality was done in #3 via #5

Currently these display as lowercase, and they should be displayed as uppercase

Changes proposed in this pull request:
* Updated A-Z links to uppercase

@ucsdlib/developers - please review
