### PR TITLE
Clarify pull --rebase to avoid merge commits

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,16 @@ Please use the following process for creating a new [Pull Request](https://help.
 
 1. Create a feature branch for new work.
 2. Push commits to the feature branch, with appropriate test coverage (and tests passing).
-3. Prior to creating a Pull Request, pull from the remote 'develop' branch to make sure your feature branch is up to date. Fix any merge conflicts and make sure all tests still pass.
+3. Prior to creating a Pull Request, make sure your branch is up to date with its parent branch (usually
+   `develop`)
+   - Pull and Rebase against parent branch
+   ```
+git checkout develop
+git pull --rebase
+git checkout <your-feature-branch>
+git rebase develop
+```
+ - Run your tests again.
 4. Create a pull request by going to the branch in github (e.g. https://github.com/ucsdlib/horton/tree/branchname/) and clicking on the pull request button (green arrows going in a circle). Make sure the PR can be merged automatically, if it can't go back to Step 3.
 5. Give the pull request a short meaningful title, and put a link to the relevant Github issue (following the ISSUE_TEMPLATE syntax).
 6. The entire `@ucsdlib/developers` team has an opportunity to review. At least


### PR DESCRIPTION
The purpose behind this PR is to simply clarify expectations on how to ensure a local feature branch is up to date prior to creating a PR. A more thorough description of the differences can be found in the [Git rebase docs](https://git-scm.com/book/en/v1/Git-Branching-Rebasing).

The intended result of this is to avoid having our commit history filled with merge commits such as:

`Merge branch 'develop' into feature/new-widget`

Changes proposed in this pull request:
* When pulling from the parent branch for changes, include the `--rebase` option
* Rebase onto feature branch from parent branch (instead of merge)

@ucsdlib/developers - please review
