### PR TITLE
Amend PR Procedure

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,19 +5,20 @@ Please use the following process for creating a new [Pull Request](https://help.
 
 1. Create a feature branch for new work.
 2. Push commits to the feature branch, with appropriate test coverage (and tests passing).
-3. Prior to creating a Pull Request, make sure your branch is up to date with its parent branch (usually
-   `develop`)
-   - Pull and Rebase against parent branch
-   ```
+3. Prior to creating a Pull Request, make sure your branch is up to date with its parent branch (usually `develop`)
+```
 git checkout develop
 git pull --rebase
 git checkout <your-feature-branch>
 git rebase develop
 ```
- - Run your tests again.
-4. Create a pull request by going to the branch in github (e.g. https://github.com/ucsdlib/horton/tree/branchname/) and clicking on the pull request button (green arrows going in a circle). Make sure the PR can be merged automatically, if it can't go back to Step 3.
-5. Give the pull request a short meaningful title, and put a link to the relevant Github issue (following the ISSUE_TEMPLATE syntax).
-6. The entire `@ucsdlib/developers` team has an opportunity to review. At least
+4. Run your tests again.
+5. Push your changes to a remote branch `git push origin <your-feature-branch>`
+
+  _Note: If you already have pushed your feature branch to Github, you may have to_: `git push --force-with-lease origin <your-feature-branch>`
+6. Create a pull request by going to the branch in github (e.g. https://github.com/ucsdlib/horton/tree/branchname/) and clicking on the pull request button (green arrows going in a circle). Make sure the PR can be merged automatically, if it can't go back to Step 3.
+7. Give the pull request a short meaningful title, and put a link to the relevant Github issue (following the ISSUE_TEMPLATE syntax).
+8. The entire `@ucsdlib/developers` team has an opportunity to review. At least
    one Review needs to be approved. Ideally, two people will sign off.
 
 ## Merging Changes from Pull Requests

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,9 +13,8 @@ git checkout <your-feature-branch>
 git rebase develop
 ```
 4. Run your tests again.
-5. Push your changes to a remote branch `git push origin <your-feature-branch>`
-
-  _Note: If you already have pushed your feature branch to Github, you may have to_: `git push --force-with-lease origin <your-feature-branch>`
+5. Push your changes to a remote branch. If you already have pushed your feature branch to Github, you may have to use the  
+`git push --force-with-lease origin <your-feature-branch>` option instead.
 6. Create a pull request by going to the branch in github (e.g. https://github.com/ucsdlib/horton/tree/branchname/) and clicking on the pull request button (green arrows going in a circle). Make sure the PR can be merged automatically, if it can't go back to Step 3.
 7. Give the pull request a short meaningful title, and put a link to the relevant Github issue (following the ISSUE_TEMPLATE syntax).
 8. The entire `@ucsdlib/developers` team has an opportunity to review. At least


### PR DESCRIPTION
This follows a conversation with @hweng on clarifying the need to both:

a) push to the remote branch after rebasing and running tests locally
b) using the `--force-with-lease` option in the case where a remote branch already exists.

The issue with (b) may need a bit more investigation, since while this has normally worked fine in my experience, we ran into an issue just today with a feature branch of Huawei's that didn't work using the lease option. We'll test more and verify.

Also, when merging this PR, please use the "Squash and Merge" option and squash the `minor markdown syntax tweaks...` commit so that's not in the history.

@ucsdlib/developers - please review