### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,11 +13,12 @@ git checkout <your-feature-branch>
 git rebase develop
 ```
 4. Run your tests again.
-5. Push your changes to a remote branch. If you already have pushed your feature branch to Github, you may have to use the  
+5. Run rubocop `rubocop` (unless you already have it integrated into your IDE/Editor) and fix reported issues. This can be done automatically in some cases with `rubocop -a` 
+6. Push your changes to a remote branch. If you already have pushed your feature branch to Github, you may have to use the  
 `git push --force-with-lease origin <your-feature-branch>` option instead.
-6. Create a pull request by going to the branch in github (e.g. https://github.com/ucsdlib/horton/tree/branchname/) and clicking on the pull request button (green arrows going in a circle). Make sure the PR can be merged automatically, if it can't go back to Step 3.
-7. Give the pull request a short meaningful title, and put a link to the relevant Github issue (following the ISSUE_TEMPLATE syntax).
-8. The entire `@ucsdlib/developers` team has an opportunity to review. At least
+7. Create a pull request by going to the branch in github (e.g. https://github.com/ucsdlib/horton/tree/branchname/) and clicking on the pull request button (green arrows going in a circle). Make sure the PR can be merged automatically, if it can't go back to Step 3.
+8. Give the pull request a short meaningful title, and put a link to the relevant Github issue (following the ISSUE_TEMPLATE syntax).
+9. The entire `@ucsdlib/developers` team has an opportunity to review. At least
    one Review needs to be approved. Ideally, two people will sign off.
 
 ## Merging Changes from Pull Requests


### PR DESCRIPTION
Ensure running rubocop locally is integrated into the development workflow.

refs #108 #114 

Somewhat related, though we're clearly running into some issues upstream with Hound, is to ensure `rubocop` is run locally prior to submitting any PR. This just clarifies that.

Changes proposed in this pull request:
* Clarify expectations around local usage of rubocop in the development workflow

@ucsdlib/developers - please review
