### PR TITLE
change methodz property to methodology

### DIFF
--- a/app/models/vocab/ucsd_terms.rb
+++ b/app/models/vocab/ucsd_terms.rb
@@ -15,7 +15,7 @@ class UcsdTerms < RDF::StrictVocabulary('http://library.ucsd.edu/ontology/dams5.
   term :localAttribution, label: "localAttribution".freeze, type: 'rdf:Property'.freeze
   term :locationOfOriginals, label: "locationOfOriginals".freeze, type: 'rdf:Property'.freeze
   term :materialDetails, label: "materialDetails".freeze, type: 'rdf:Property'.freeze
-  term :methods, label: "methods".freeze, type: 'rdf:Property'.freeze
+  term :methodology, label: "methods".freeze, type: 'rdf:Property'.freeze
   term :publication, label: "publication".freeze, type: 'rdf:Property'.freeze
   term :physicalDescription, label: "physicalDescription".freeze, type: 'rdf:Property'.freeze
   term :relationshipToOtherLoci, label: "relationshipToOtherLoci".freeze, type: 'rdf:Property'.freeze

--- a/app/schemas/general_schema.rb
+++ b/app/schemas/general_schema.rb
@@ -17,7 +17,7 @@ class GeneralSchema < ActiveTriples::Schema
   property :local_attribution, predicate: ::UcsdTerms.localAttribution
   property :location_of_originals, predicate: ::UcsdTerms.locationOfOriginals, multiple: false
   property :material_details, predicate: ::UcsdTerms.materialDetails
-  property :methodz, predicate: ::UcsdTerms.methods
+  property :methodology, predicate: ::UcsdTerms.methodology
   property :physical_description, predicate: ::UcsdTerms.physicalDescription
   property :publication, predicate: ::UcsdTerms.publication
   property :relationship_to_otherLoci, predicate: ::UcsdTerms.relationshipToOtherLoci


### PR DESCRIPTION
Per conversation with @ucsdlib/domm and @lsitu -- We are leaving the label as 'methods' but changing the property name to avoid the keyword conflict with using methods as a property in Ruby.

Changes proposed in this pull request:
* `methodz` -> `methodology`

@ucsdlib/developers - please review
