### PR TITLE
Only run CircleCI test suite once

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,3 @@ dependencies:
 database:
   override:
     - bundle exec rake db:migrate
-
-test:
-  override:
-    - bundle exec rake spec


### PR DESCRIPTION
The CircleCI project settings for horton appear to already be configured to run the test suite and pass the coveralls environment variable via the CircleCI UI configuration [1].

As a result, our CircleCI builds have been running the test suite twice,
adding another 10+ minutes to the overall process.

1. https://circleci.com/gh/ucsdlib/horton/edit#tests

Changes proposed in this pull request:
* Remove the extra call to run the test suite in the config file

@ucsdlib/developers - please review
