### PR TITLE
Fixes 136 - Fixed OpenSeaDragon viewer for objects with no representative id and improved test coverage.

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -8,7 +8,7 @@
     </header>
 
     <!-- Add OpenSeaDragon Viewer -->
-    <% if Rails.configuration.iiif_enabled %>
+    <% if @presenter.representative_id %>
       <div class="open_seadragon_widget">
         <%= openseadragon_picture_tag "#{iiif_url ActiveFedora::Base.search_by_id(@presenter.representative_id)}/info.json" %>
       </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,9 +70,6 @@ Rails.application.configure do
   # url base for local authorities
   config.authority_path = 'http://localhost:3000/dams_authorities'
 
-  # enable IIIF
-  config.iiif_enabled = true
-
   # url base for IIIF sever
   config.iiif_baseurl = 'http://localhost:8182/iiif/2/'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,9 +102,6 @@ Rails.application.configure do
   # url base for local authorities
   config.authority_path = 'http://localhost:3000/dams_authorities'
 
-  # enable IIIF
-  config.iiif_enabled = true
-
   # url base for IIIF sever
   config.iiif_baseurl = 'http://localhost:8182/iiif/2/'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,9 +58,6 @@ Rails.application.configure do
   # url base for local authorities
   config.authority_path = 'http://localhost:3000/dams_authorities'
 
-  # enable IIIF
-  config.iiif_enabled = false
-
   # url base for IIIF sever
   config.iiif_baseurl = 'http://localhost:8182/iiif/2/'
 end

--- a/spec/factories/object_resources.rb
+++ b/spec/factories/object_resources.rb
@@ -102,5 +102,15 @@ FactoryGirl.define do
         2.times { obj.ordered_members << FactoryGirl.create(:culturally_sensitive_file_set, user: evaluator.user) }
       end
     end
+
+    factory :object_with_image_file do
+      after(:create) do |object_resource, evaluator|
+        file_path = Rails.root.join("spec", "fixtures", "files", "file_1.jpg")
+        file = FactoryGirl.create(:file_set, user: evaluator.user, content: File.open(file_path))
+        object_resource.ordered_members << file
+        object_resource.representative_id = file.id
+        object_resource.save
+      end
+    end
   end
 end

--- a/spec/features/object_resource_spec.rb
+++ b/spec/features/object_resource_spec.rb
@@ -244,6 +244,28 @@ feature 'ObjectResource' do
     end
   end
 
+  context 'IIIF OpenSeaDragon viewer' do
+    let(:user) { create(:admin) }
+    let(:object_with_file) { FactoryGirl.create(:object_with_image_file, title: ["Object - IIIF Viewer"], user: user) }
+
+    before do
+      sign_in user
+    end
+
+    scenario 'has no OpenSeaDragon widget' do
+      visit new_hyrax_object_resource_path
+      fill_in 'Title', with: 'Test ObjectResource - IIIF OpenSeaDragon'
+      click_button 'Save'
+      expect(page).to have_content 'Test ObjectResource - IIIF OpenSeaDragon'
+      expect(page).not_to have_selector "div[class='open_seadragon_widget']"
+    end
+
+    scenario 'has OpenSeaDragon widget' do
+      visit hyrax_object_resource_path object_with_file.id
+      expect(page).to have_selector "div[class='open_seadragon_widget']"
+    end
+  end
+
   context 'a logged in user in editor role' do
     let(:user) { create(:editor) }
 

--- a/spec/hyrax/file_sets/media_display/_image.html.erb_spec.rb
+++ b/spec/hyrax/file_sets/media_display/_image.html.erb_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe "hyrax/file_sets/show.html.erb", type: :view do
   let(:ability) { double }
   let(:file_set_presenter) { FileSetPresenter.new(file_set_document, :ability) }
 
-  before do
-    @iiif_enabled = Rails.configuration.iiif_enabled
-  end
-
-  after do
-    Rails.configuration.iiif_enabled = @iiif_enabled
-  end
-
   context 'IIIF viewer' do
     let(:picture_tag) { '<picture><source media="openseadragon" src="p1.tif/info.json" /></picture>' }
 


### PR DESCRIPTION
Fixes #136

Fixed the error for OpenSeaDragon viewer for objects with no representative id and added more tests to improv test coverages.

@ucsdlib/developers - please review
